### PR TITLE
updates on scoped timings and outputs

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -44,6 +44,7 @@ ci_requires = [
     'pytest-datadir',
     'pytest-timeout',
     'docutils',
+    'numpy',
 ]
 # these don't go into the pip extras
 optional_requirements_file_only = []

--- a/dependencies.py
+++ b/dependencies.py
@@ -14,7 +14,7 @@ def setup_requires():
     ]
 
 
-install_requires = ['packaging', 'typer'] + setup_requires()
+install_requires = ['packaging', 'typer', 'rich'] + setup_requires()
 install_suggests = {
     'matplotlib': 'needed for error plots in demo scipts',
     'mpi4py': 'needed for global data operations',

--- a/examples/scopes_and_decorators.ipynb
+++ b/examples/scopes_and_decorators.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee811163",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "from pytimings.timer import scoped_timing, function_timer, global_timings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9222140a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@function_timer(section_name=\"my_function\")\n",
+    "def sleep(seconds=1):\n",
+    "    init_time = time.time()\n",
+    "    while time.time() < init_time + seconds:\n",
+    "        pass\n",
+    "    return time.time() - init_time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48d97018",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with scoped_timing(section_name=\"my_scope\"):\n",
+    "    sleep(1)\n",
+    "    sleep(0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72ba8ab9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "global_timings.output_console()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pytimings/timer.py
+++ b/pytimings/timer.py
@@ -223,7 +223,7 @@ def scoped_timing(section_name, log_function=None, timings=None):
     finally:
         delta = timings.stop(section_name)
         if log_function:
-            log_function(f"Executing {section_name} took {delta.wall * TO_SECONDS_FACTOR}s\n")
+            log_function(f"Executing {section_name} took {delta.wall}s\n")
 
 
 def function_timer(section_name, log_function=None, timings=None):

--- a/pytimings/timer.py
+++ b/pytimings/timer.py
@@ -132,7 +132,7 @@ class Timings:
 
     def walltime(self, section_name: str) -> int:
         """get runtime of section in milliseconds"""
-        return self.delta(section_name)[WALL_TIME]
+        return self.delta(section_name)[0]
 
     def delta(self, section_name: str) -> Dict[str, int]:
         """get the full delta dict"""
@@ -166,10 +166,10 @@ class Timings:
     def output_simple(self, out=None):
         """outputs walltime only w/o MPI-rank averaging"""
         out = out or sys.stdout
-        for section in self._commited_deltas.keys:
+        for section in self._commited_deltas.keys():
             out.write(f"{self._csv_sep}{section}")
         for delta in self._commited_deltas.values():
-            out.write(f"{self._csv_sep}{delta[WALL_TIME]}")
+            out.write(f"{self._csv_sep}{delta[0]}")
 
     def output_all_measures(self, out=None, mpi_comm=None) -> None:
         """output all recorded measures

--- a/pytimings/timer.py
+++ b/pytimings/timer.py
@@ -215,7 +215,7 @@ global_timings = Timings()
 
 
 @contextmanager
-def scoped_timing(section_name, log_function=None, timings=None):
+def scoped_timing(section_name, log_function=None, timings=None, format=''):
     timings = timings or global_timings
     timings.start(section_name)
     try:
@@ -223,7 +223,7 @@ def scoped_timing(section_name, log_function=None, timings=None):
     finally:
         delta = timings.stop(section_name)
         if log_function:
-            log_function(f"Executing {section_name} took {delta.wall}s\n")
+            log_function(f"Executing {section_name} took {delta.wall:^{format}}s\n")
 
 
 def function_timer(section_name, log_function=None, timings=None):

--- a/pytimings/timer.py
+++ b/pytimings/timer.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 import time
 from contextlib import contextmanager
-
+from datetime import timedelta
 from io import StringIO
 from collections import namedtuple, defaultdict
 from pathlib import Path
@@ -163,13 +163,20 @@ class Timings:
             open(a_filename, "wt").write(tmp_out.read())
             return a_filename
 
-    def output_simple(self, out=None):
+    def output_console(self):
         """outputs walltime only w/o MPI-rank averaging"""
-        out = out or sys.stdout
-        for section in self._commited_deltas.keys():
-            out.write(f"{self._csv_sep}{section}")
-        for delta in self._commited_deltas.values():
-            out.write(f"{self._csv_sep}{delta[0]}")
+        from rich import console, table, box
+
+        csl = console.Console()
+        tbl = table.Table(show_header=True, header_style="bold magenta", box=box.SIMPLE_HEAVY)
+        tbl.add_column("Section")
+        tbl.add_column(
+            "Walltime (HH:MM:SS)",
+            justify="right",
+        )
+        for section, delta in self._commited_deltas.items():
+            tbl.add_row(section, str(timedelta(seconds=delta[0])))
+        csl.print(tbl)
 
     def output_all_measures(self, out=None, mpi_comm=None) -> None:
         """output all recorded measures

--- a/pytimings/timer.py
+++ b/pytimings/timer.py
@@ -134,6 +134,9 @@ class Timings:
         """get runtime of section in milliseconds"""
         return self.delta(section_name)[0]
 
+    def add_walltime(self, section_name: str, time: int) -> None:
+        self._commited_deltas[section_name] = TimingDelta(time)
+
     def delta(self, section_name: str) -> Dict[str, int]:
         """get the full delta dict"""
         try:

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,6 +5,7 @@ black
 check-manifest
 codecov
 docutils
+numpy
 pre-commit
 pytest
 pytest-cov

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -7,6 +7,7 @@ packaging
 psutil
 pytest-runner>=2.9
 python-slugify
+rich
 setuptools>=40.8.0,<49.2.0
 sphinx-autoapi>=1.7
 sphinx-material

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 packaging
 psutil
 pytest-runner>=2.9
+rich
 setuptools>=40.8.0,<49.2.0
 typer
 wheel

--- a/tests/test_pytimings.py
+++ b/tests/test_pytimings.py
@@ -116,6 +116,13 @@ def test_decorator(timings_object):
     _assert(delta_after.user, lower=delta_before.user)
 
 
+def test_simple_output(timings_object):
+    with scoped_timing("time", print, timings=timings_object, format='.5f'):
+        default_sleep()
+    timings_object.walltime("time")
+    timings_object.output_simple()
+
+
 def test_command_line_interface():
     """Test the CLI."""
     runner = CliRunner()

--- a/tests/test_pytimings.py
+++ b/tests/test_pytimings.py
@@ -119,8 +119,10 @@ def test_decorator(timings_object):
 def test_simple_output(timings_object):
     with scoped_timing("time", print, timings=timings_object, format='.5f'):
         default_sleep()
+    with scoped_timing("a much longer section name", print, timings=timings_object):
+        _busywait(1)
     timings_object.walltime("time")
-    timings_object.output_simple()
+    timings_object.output_console()
 
 
 def test_command_line_interface():

--- a/tests/test_pytimings.py
+++ b/tests/test_pytimings.py
@@ -4,6 +4,7 @@
 import pickle
 import sys
 import time
+import numpy as np
 from functools import partial
 from tempfile import TemporaryFile
 
@@ -117,12 +118,18 @@ def test_decorator(timings_object):
 
 
 def test_simple_output(timings_object):
+    # simple output with optional format specifier
     with scoped_timing("time", print, timings=timings_object, format='.5f'):
         default_sleep()
     with scoped_timing("a much longer section name", print, timings=timings_object):
         _busywait(1)
-    timings_object.walltime("time")
+    scoped_sleepy_time = timings_object.walltime("time")
     timings_object.output_console()
+
+    # add a known walltime to the timings object
+    timings_object.add_walltime('sleepy_time', DEFAULT_SLEEP_SECONDS)
+    sleepy_time = timings_object.walltime("sleepy_time")
+    np.isclose(scoped_sleepy_time, sleepy_time)
 
 
 def test_command_line_interface():


### PR DESCRIPTION
I found some issues in the printout for timings. 
Are these lines tested somewhere? A small test for me was 

```
from pytimings.timer import global_timings as timings, scoped_timing
import time

with scoped_timing("online_FEM", print):
    print('\nsleeping a bit...')
    time.sleep(5)

timings.walltime("online_FEM")
timings.output_simple()
```

which now works in this PR. 
One small other thing however is that for me the `TO_SECONDS_FACTOR` was incorrect which I fixed in https://github.com/WWU-AMM/pytimings/commit/54770577454b131ace6c7838e09078ee1942fed8, but did not include in this PR. Can you have a look?